### PR TITLE
Rename build target macos => darwin

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ fn main() {
             .compile("libhidapi.a");
         println!("cargo:rustc-link-lib=setupapi");
 
-    } else if target.contains("macos") {
+    } else if target.contains("darwin") {
         cc::Build::new()
             .file("etc/hidapi/mac/hid.c")
             .include("etc/hidapi/hidapi")


### PR DESCRIPTION
`build.rs` target `macos` looks obsolete. Now it returns `x86_64-apple-darwin`. I'm able to reproduce this both on my laptop and travis-ci. So maybe it's time to change it.
 
The simple way to reproduce the issue is by cloning this repo and running `cargo test`. Travis tests were also broken.

The target mismatch affects on using ethcore crate with distinct projects. I described this in the issue https://github.com/paritytech/parity/issues/8407